### PR TITLE
`README.md` improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 [Website](https://orbitalhq.com)&nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp;
 [Docs](https://orbitalhq.com/docs)&nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp;
-[Blog](https://orbitalhq.com/blog)&nbsp;&nbsp;&nbsp;
+[Blog](https://orbitalhq.com/blog)&nbsp;&nbsp;&nbsp;•&nbsp;&nbsp;&nbsp;
 [Get in touch](#)
 
 </div>
@@ -157,15 +157,15 @@ Orbital gives you many of the benefits of GraphQL (API federation, custom respon
 The key differences are:
 
 ##### Technology agnostic
-GraphQL works great when you have GraphQL everywhere.  For everything else, you have to maintain a seperate shim layer to adapt your RESTful API / Database / Message Queue etc., to GraphQL.
+GraphQL works great when you have GraphQL everywhere.  For everything else, you have to maintain a separate shim layer to adapt your RESTful API / Database / Message Queue etc., to GraphQL.
 
-Orbital and Taxi work by embedding metatdata in your existing API specs (OpenAPI / Protobuf / Avro / JsonSchema, etc), so that you don't need to change the underlying tech you're using.
+Orbital and Taxi work by embedding metadata in your existing API specs (OpenAPI / Protobuf / Avro / JsonSchema, etc), so that you don't need to change the underlying tech you're using.
 
 ##### Decentralized, spec-first federation
-Orbital is built for decentralized teams, so that teams can ship changes independently, without having to build and maintain a seperate integration layer.
+Orbital is built for decentralized teams, so that teams can ship changes independently, without having to build and maintain a separate integration layer.
 
 ##### Resolver-free
-Resolvers in GraphQL are integration code that has to be maintated - often by a dedicated GraphQL / middleware team.  This means teams that own services have to co-ordinate changes with a seperate integration team.
+Resolvers in GraphQL are integration code that has to be maintained - often by a dedicated GraphQL / middleware team.  This means teams that own services have to co-ordinate changes with a separate integration team.
 
 Instead, Orbital uses Taxi metadata embedded in API specs to define how data relates semantically.  From here, most integration can be created automatically.
 
@@ -184,4 +184,3 @@ or implementing the spec from scratch in Taxi (it's really quick)
  * [Why we built Taxi](https://orbitalhq.com/blog/2023-05-12-why-we-created-taxi)
  * [Using Semantic Metadata to automate integration](https://orbitalhq.com/blog/2023-01-16-using-semantic-metadata)
  * [Querying for data](https://orbitalhq.com/docs/querying/writing-queries)
- * 

--- a/auth-server/README.md
+++ b/auth-server/README.md
@@ -12,7 +12,7 @@ Just run:
 docker-compose up -d
 ```
 
-The admin console is then avaiable on `http://localhost:8080/admin`
+The admin console is then available on `http://localhost:8080/admin`
 
 Log in with username/password `admin/admin`
 

--- a/regression-tests/README.md
+++ b/regression-tests/README.md
@@ -30,7 +30,7 @@ mvn verify -Dvyne.tag=<DESIRED DOCKER IMAGE LABEL>
 
 e.g.
 
-mvn verify -Dvyne-tag=latest-snasphost
+mvn verify -Dvyne-tag=latest-snapshot
 
 # I don't want to deal with docker containers, I just want to run the system (vyne, cask etc.) locally and run test against my local
 

--- a/voyager/README.md
+++ b/voyager/README.md
@@ -14,5 +14,5 @@ low.
 
 Instead, the web app is built in parallel to the main java app.
 
-Our docker build combines the two (see `Dockerfile`), and configrures
+Our docker build combines the two (see `Dockerfile`), and configures
 the spring boot app to serve from `opt/service/webapp`

--- a/vyne-query-service/README.md
+++ b/vyne-query-service/README.md
@@ -12,5 +12,5 @@ low.
 
 Instead, the web app is built in parallel to the main java app.
 
-Our docker build combines the two (see `Dockerfile`), and configrures
+Our docker build combines the two (see `Dockerfile`), and configures
 the spring boot app to serve from `opt/service/webapp`

--- a/vyne-query-service/src/main/web/README.md
+++ b/vyne-query-service/src/main/web/README.md
@@ -6,5 +6,5 @@ simplified.
 * `./src/taxi-playground-app`: The app now know as "Voyager", deployed at voyager.orbitalhq.com
 * `./src/orbital-app`: Our UI container for Orbital. While the Vyne UI isn't dead, active development is focussed on
   this.
-* `./src/app`: The original UI, built and deplyoed as part of Vyne. 
+* `./src/app`: The original UI, built and deployed as part of Vyne. 
 


### PR DESCRIPTION
Noticed a couple of issues with the documentation:

- Formatting
    - Missing final separator
       ![image](https://github.com/orbitalapi/orbital/assets/8626721/01e55926-2e05-4eac-9c06-639327d5ceff)
    - Extra empty list item
       ![image](https://github.com/orbitalapi/orbital/assets/8626721/cd766caf-6727-4a2b-964d-ed1ed6936b15)
- Typos
